### PR TITLE
Xyz background layers

### DIFF
--- a/qgiscloud/openlayers_menu.py
+++ b/qgiscloud/openlayers_menu.py
@@ -52,7 +52,7 @@ class OpenlayersMenu(QMenu):
 
         self._olLayerTypeRegistry.register(OlOpenStreetMapLayer())
         self._olLayerTypeRegistry.register(OlOSMHumanitarianDataModelLayer())
-                
+
         self._olLayerTypeRegistry.register(OlOpenCycleMapLayer())
         self._olLayerTypeRegistry.register(OlOCMLandscapeLayer())
         self._olLayerTypeRegistry.register(OlOCMPublicTransportLayer())
@@ -61,8 +61,7 @@ class OpenlayersMenu(QMenu):
         self._olLayerTypeRegistry.register(OlOCMSpinalMapLayer())
         self._olLayerTypeRegistry.register(OlOCMPioneerLayer())
         self._olLayerTypeRegistry.register(OlOCMMobileAtlasLayer())
-        self._olLayerTypeRegistry.register(OlOCMNeighbourhoodLayer())        
-
+        self._olLayerTypeRegistry.register(OlOCMNeighbourhoodLayer())
 
         self._olLayerTypeRegistry.register(OlBingRoadLayer())
         self._olLayerTypeRegistry.register(OlBingAerialLayer())
@@ -88,21 +87,20 @@ class OpenlayersMenu(QMenu):
             self.iface, self.setReferenceLayer, self._olLayerTypeRegistry)
         QgsApplication.pluginLayerRegistry().addPluginLayerType(self.pluginLayerType)
 
-        
-
     def addLayer(self, layerType):
         layer = None
         if layerType.hasXYZUrl():
             xyzUrl = layerType.xyzUrlConfig()
-            layer = QgsRasterLayer( 'url=' + xyzUrl + '&type=xyz', layerType.displayName, 'wms' )
+            layer = QgsRasterLayer(
+                'url=' + xyzUrl + '&type=xyz', layerType.displayName, 'wms')
         else:
             layer = OpenlayersLayer(self.iface, self._olLayerTypeRegistry)
             layer.setName(layerType.displayName)
             layer.setLayerType(layerType)
-            
+
         if not layer.isValid():
             return
-        
+
         coordRefSys = layerType.coordRefSys(self.canvasCrs())
         self.setMapCrs(coordRefSys)
         QgsProject.instance().addMapLayer(layer)
@@ -131,10 +129,11 @@ class OpenlayersMenu(QMenu):
         mapCanvas = self.iface.mapCanvas()
         canvasCrs = self.canvasCrs()
         if canvasCrs != coordRefSys:
-            coordTrans = QgsCoordinateTransform(canvasCrs, coordRefSys,  QgsProject.instance())
+            coordTrans = QgsCoordinateTransform(
+                canvasCrs, coordRefSys,  QgsProject.instance())
             extMap = mapCanvas.extent()
-            extMap = coordTrans.transform(extMap, QgsCoordinateTransform.ForwardTransform)
-            QgsProject.instance().setCrs( coordRefSys )
+            extMap = coordTrans.transform(
+                extMap, QgsCoordinateTransform.ForwardTransform)
+            QgsProject.instance().setCrs(coordRefSys)
             mapCanvas.freeze(False)
             mapCanvas.setExtent(extMap)
-

--- a/qgiscloud/openlayers_menu.py
+++ b/qgiscloud/openlayers_menu.py
@@ -103,7 +103,9 @@ class OpenlayersMenu(QMenu):
 
         coordRefSys = layerType.coordRefSys(self.canvasCrs())
         self.setMapCrs(coordRefSys)
-        QgsProject.instance().addMapLayer(layer)
+        QgsProject.instance().addMapLayer(layer, False)
+        legendRootGroup = self.iface.layerTreeView().layerTreeModel().rootGroup()
+        legendRootGroup.insertLayer(len(legendRootGroup.children()), layer)
 
         # last added layer is new reference
         self.setReferenceLayer(layer)

--- a/qgiscloud/openlayers_menu.py
+++ b/qgiscloud/openlayers_menu.py
@@ -91,16 +91,24 @@ class OpenlayersMenu(QMenu):
         
 
     def addLayer(self, layerType):
-        layer = OpenlayersLayer(self.iface, self._olLayerTypeRegistry)
-        layer.setName(layerType.displayName)
-        layer.setLayerType(layerType)
-        if layer.isValid():
-            coordRefSys = layerType.coordRefSys(self.canvasCrs())
-            self.setMapCrs(coordRefSys)
-            QgsProject.instance().addMapLayer(layer)
+        layer = None
+        if layerType.hasXYZUrl():
+            xyzUrl = layerType.xyzUrlConfig()
+            layer = QgsRasterLayer( 'url=' + xyzUrl + '&type=xyz', layerType.displayName, 'wms' )
+        else:
+            layer = OpenlayersLayer(self.iface, self._olLayerTypeRegistry)
+            layer.setName(layerType.displayName)
+            layer.setLayerType(layerType)
+            
+        if not layer.isValid():
+            return
+        
+        coordRefSys = layerType.coordRefSys(self.canvasCrs())
+        self.setMapCrs(coordRefSys)
+        QgsProject.instance().addMapLayer(layer)
 
-            # last added layer is new reference
-            self.setReferenceLayer(layer)
+        # last added layer is new reference
+        self.setReferenceLayer(layer)
 
     def setReferenceLayer(self, layer):
         self.layer = layer

--- a/qgiscloud/openlayers_menu.py
+++ b/qgiscloud/openlayers_menu.py
@@ -126,7 +126,7 @@ class OpenlayersMenu(QMenu):
             coordTrans = QgsCoordinateTransform(canvasCrs, coordRefSys,  QgsProject.instance())
             extMap = mapCanvas.extent()
             extMap = coordTrans.transform(extMap, QgsCoordinateTransform.ForwardTransform)
-            mapCanvas.setDestinationCrs(coordRefSys)
+            QgsProject.instance().setCrs( coordRefSys )
             mapCanvas.freeze(False)
             mapCanvas.setExtent(extMap)
 


### PR DESCRIPTION
It will be good to use xyz-layers in QGIS (instead of the openlayers plugin layers ) where possible. This  PR creates xyz-layers if they have an xyz-url (e.g. openstreetmap). Once the backend code is changed to load xyz-layers directly in the webmap (e.g. not cascaded), this PR can be merged.